### PR TITLE
Added ":=" for operators and variable declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "pine-script-syntax-highlighter",
     "displayName": "Pine Script Syntax Highlighter",
     "description": "Write awesome indicators or strategies with me!",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "author": "Yankı Küçük <kendinikertenkelebek@me.com> (https://github.com/kendinikertenkelebek)",
     "publisher": "ex-codes",
     "icon": "images/pinescript.png",

--- a/syntaxes/pinescript.tmLanguage.json
+++ b/syntaxes/pinescript.tmLanguage.json
@@ -51,7 +51,7 @@
 				},
 				{
 					"begin": "'",
-					"beginCaptures": { 
+					"beginCaptures": {
 						"1": {
 							"name": "punctuation.definition.string.begin.pine"
 						}
@@ -75,7 +75,7 @@
 		"keywords": {
 			"patterns": [
 				{
-					"match": "\\b(if|else|continue|break|for|return)\\b",
+					"match": "\\b(if|else|continue|break|for|return|var)\\b",
 					"name": "keyword.control.pine"
 				}
 			]
@@ -143,7 +143,7 @@
 		"variables": {
 			"patterns": [
 				{
-					"match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=)",
+					"match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=|:=)",
 					"name": "variable.other.pine"
 				}
 			]
@@ -186,7 +186,7 @@
 					"name": "keyword.operator.logical.pine"
 				},
 				{
-					"match": "=",
+					"match": "(=|:=)",
 					"name": "keyword.operator.assignment.pine"
 				}
 			]


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Added ":=" for operators and variable declarations, also added "var" as a keyword. It is part of Pine Script 4.

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.